### PR TITLE
Update ci-krkrsdl2.yml for supprting Apple Silicon

### DIFF
--- a/.github/workflows/ci-krkrsdl2.yml
+++ b/.github/workflows/ci-krkrsdl2.yml
@@ -233,7 +233,7 @@
       ]
     },
     "build-macos-cmake" : {
-      "runs-on" : "macos-11",
+      "runs-on" : "macos-14",
       "timeout-minutes" : 20,
       "steps" : [
         {
@@ -249,7 +249,7 @@
         },
         {
           "name" : "Configure project",
-          "run" : "cmake -S . -B build"
+          "run" : "cmake -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' -S . -B build"
         },
         {
           "name" : "Build project",
@@ -282,7 +282,7 @@
       "steps" : [
         {
           "name" : "Download all artifacts",
-          "uses" : "actions/download-artifact@v3"
+          "uses" : "actions/download-artifact@master"
         },
         {
           "name" : "Prepare artifacts for release",


### PR DESCRIPTION
Changed for running on Apple Silicon without Rosetta 2.
I have confirmed that it runs on an M1 Macbook Air and is a universal binary.

<img width="559" alt="image" src="https://github.com/krkrsdl2/fstat/assets/58556570/90a6ad73-a6b4-4bc8-aef4-62232a5d6ab0">
